### PR TITLE
fix: pin container image to v0.2.1 instead of mutable latest tag (#31)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
         - name: whisperx-server
-          image: whisperx-server:latest
+          image: whisperx-server:v0.2.1
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/k8s/local/all-in-one.yaml
+++ b/k8s/local/all-in-one.yaml
@@ -57,7 +57,7 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
         - name: whisperx-server
-          image: whisperx-server:latest
+          image: whisperx-server:v0.2.1
           imagePullPolicy: Never
           ports:
             - containerPort: 9090


### PR DESCRIPTION
Replace `whisperx-server:latest` with `whisperx-server:v0.2.1` in K8s deployment and local all-in-one manifests for reproducible deployments.

Closes #31