### PR TITLE
fix: send generic error message to clients instead of e.what() (#32)

### DIFF
--- a/src/server/websocket_server.hpp
+++ b/src/server/websocket_server.hpp
@@ -619,7 +619,7 @@ private:
                 reinterpret_cast<const uint8_t*>(data.data()), data.size());
         } catch (const std::exception& e) {
             spdlog::error("Audio ingestion error: session={} error={}", conn->session_id, e.what());
-            send_error(ws, conn->session_id, "AUDIO_ERROR", e.what());
+            send_error(ws, conn->session_id, "AUDIO_ERROR", "Audio processing failed");
             return;
         }
 


### PR DESCRIPTION
Replace internal exception details (`e.what()`) with generic `Audio processing failed` message in client-facing WebSocket error responses. Internal details are still logged server-side via `spdlog::error`.

Closes #32