### PR TITLE
fix: default to wss:// (secure WebSocket) in tooling (#34)

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -412,7 +412,7 @@ async def run_benchmark(
 
 def main():
     parser = argparse.ArgumentParser(description="OpenASR Benchmark")
-    parser.add_argument("--server-url", default="ws://whisperx.local/transcribe",
+    parser.add_argument("--server-url", default="wss://whisperx.local/transcribe",
                         help="WebSocket URL")
     parser.add_argument("--api-key", default=os.environ.get("WSS_API_KEY", ""),
                         help="API key")

--- a/tools/e2e_test.py
+++ b/tools/e2e_test.py
@@ -6,7 +6,7 @@ Sends a WAV file through the WebSocket protocol and verifies
 that the server produces non-empty transcription text.
 
 Usage:
-    python e2e_test.py --server-url ws://localhost:9090/transcribe --wav test.wav
+    python e2e_test.py --server-url wss://localhost:9090/transcribe --wav test.wav
 """
 
 import argparse
@@ -106,8 +106,8 @@ def main():
     parser = argparse.ArgumentParser(description="E2E transcription test for OpenASR")
     parser.add_argument(
         "--server-url",
-        default=os.environ.get("OPENASR_WS_URL", "ws://localhost:9090/transcribe"),
-        help="WebSocket endpoint (default: ws://localhost:9090/transcribe)",
+        default=os.environ.get("OPENASR_WS_URL", "wss://localhost:9090/transcribe"),
+        help="WebSocket endpoint (default: wss://localhost:9090/transcribe)",
     )
     parser.add_argument(
         "--wav",

--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -6,7 +6,7 @@ Sends malformed, oversized, and out-of-sequence messages to verify
 the server responds with proper errors without crashing.
 
 Usage:
-    python integration_tests.py --server-url ws://localhost:9090/transcribe --api-key SECRET
+    python integration_tests.py --server-url wss://localhost:9090/transcribe --api-key SECRET
 """
 
 import argparse
@@ -24,7 +24,7 @@ import websockets
 import websockets.exceptions
 
 # ── globals set by CLI args ──────────────────────────────────────────────────
-SERVER_URL: str = "ws://localhost:9090/transcribe"
+SERVER_URL: str = "wss://localhost:9090/transcribe"
 API_KEY: str = ""
 
 
@@ -927,8 +927,8 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--server-url",
-        default=os.environ.get("OPENASR_WS_URL", "ws://localhost:9090/transcribe"),
-        help="WebSocket endpoint (default: ws://localhost:9090/transcribe)",
+        default=os.environ.get("OPENASR_WS_URL", "wss://localhost:9090/transcribe"),
+        help="WebSocket endpoint (default: wss://localhost:9090/transcribe)",
     )
     parser.add_argument(
         "--api-key",

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -17,7 +17,7 @@ import wave
 
 import websockets
 
-DEFAULT_URL = "ws://localhost:9090/transcribe"
+DEFAULT_URL = "wss://localhost:9090/transcribe"
 CHUNK_DURATION_MS = 200  # send 200ms chunks
 
 


### PR DESCRIPTION
Update default WebSocket URLs in e2e_test.py, integration_tests.py, benchmark.py, and test_client.py from `ws://` to `wss://`. Users can still override via `--server-url` or `OPENASR_WS_URL` env var.

Closes #34