### PR TITLE
fix: add allowPrivilegeEscalation: false to K8s deployments (#36)

### DIFF
--- a/k8s/deployment-gpu.yaml
+++ b/k8s/deployment-gpu.yaml
@@ -59,6 +59,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -57,6 +57,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
Explicitly disable privilege escalation in both CPU and GPU deployment manifests per CIS Kubernetes Benchmark 5.2.5.

Closes #36