### PR TITLE
fix: validate URL scheme in integration test urllib usage (#37)

### DIFF
--- a/tools/integration_tests.py
+++ b/tools/integration_tests.py
@@ -33,6 +33,8 @@ API_KEY: str = ""
 def _http_base_url() -> str:
     """Derive http(s) base URL from the WebSocket URL."""
     parsed = urlparse(SERVER_URL)
+    if parsed.scheme not in ("ws", "wss"):
+        raise ValueError(f"SERVER_URL must use ws:// or wss:// scheme, got: {parsed.scheme}")
     scheme = "https" if parsed.scheme == "wss" else "http"
     return f"{scheme}://{parsed.netloc}"
 


### PR DESCRIPTION
Add scheme validation to `_http_base_url()` to ensure only `ws://` and `wss://` schemes are accepted, preventing potential SSRF via arbitrary URL schemes passed through `--server-url`.

Closes #37