### PR TITLE
fix: move API key from ConfigMap to K8s Secret (#39)

### DIFF
--- a/k8s/local/all-in-one.yaml
+++ b/k8s/local/all-in-one.yaml
@@ -18,9 +18,18 @@ data:
   WSS_LANGUAGE: "en"
   WSS_BEAM_SIZE: "5"
   WSS_CONFIG_PATH: "/dev/null"
-  WSS_API_KEY: "dev-test-key-change-in-production"
 ---
 apiVersion: apps/v1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: whisperx-server-secrets
+  namespace: whisperx
+type: Opaque
+stringData:
+  WSS_API_KEY: "CHANGE-ME-IN-PRODUCTION"
+---
 kind: Deployment
 metadata:
   name: whisperx-server
@@ -63,6 +72,8 @@ spec:
             - containerPort: 9090
           envFrom:
             - configMapRef:
+            - secretRef:
+                name: whisperx-server-secrets
                 name: whisperx-server-config
           env:
             - name: WHISPER_MODEL_PATH


### PR DESCRIPTION
Remove hardcoded `WSS_API_KEY` from ConfigMap and store it in a Kubernetes Secret instead. Secrets are encrypted at rest (when configured) and have tighter RBAC controls than ConfigMaps.

Closes #39