### PR TITLE
fix: set CodeQL fail-on-severity to error to block critical findings (#41)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,4 +50,4 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
-          fail-on-severity: none
+          fail-on-severity: error


### PR DESCRIPTION
Change from `none` (never fails) to `error` so PRs with critical/high CodeQL findings cannot be merged without review.

Closes #41