### PR TITLE
fix: reduce WebSocket maxPayloadLength from 16MB to 256KB (#44)

### DIFF
--- a/src/server/websocket_server.hpp
+++ b/src/server/websocket_server.hpp
@@ -182,7 +182,7 @@ private:
 
         app.ws<ConnectionData>("/transcribe", {
             .compression = uWS::DISABLED,
-            .maxPayloadLength = 16 * 1024 * 1024,
+            .maxPayloadLength = 256 * 1024,
             .idleTimeout = 120,
             .maxBackpressure = 1 * 1024 * 1024,
 


### PR DESCRIPTION
Audio chunks at 16kHz mono 16-bit are ~32KB/s. A 256KB frame limit is sufficient for multi-second chunks while preventing memory pressure from burst-sized frames before rate limiting kicks in.

Closes #44