### PR TITLE
fix: add Windows portability for POSIX-only functions (#60)

### DIFF
--- a/src/logging/json_formatter.hpp
+++ b/src/logging/json_formatter.hpp
@@ -8,6 +8,17 @@
 
 namespace wss::logging {
 
+/// Portable gmtime wrapper (gmtime_r on POSIX, gmtime_s on Windows).
+inline std::tm safe_gmtime(const std::time_t* time) {
+    std::tm result{};
+#ifdef _WIN32
+    gmtime_s(&result, time);
+#else
+    gmtime_r(time, &result);
+#endif
+    return result;
+}
+
 /// Custom spdlog formatter that outputs one JSON object per log line.
 /// Compatible with Datadog, Loki, CloudWatch, and ELK log parsers.
 ///
@@ -45,8 +56,7 @@ private:
 
         std::time_t tt = std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::time_point(secs));
-        std::tm gmt{};
-        gmtime_r(&tt, &gmt);
+        std::tm gmt = safe_gmtime(&tt);
 
         // "2026-03-03T23:33:54.283Z"
         char buf[64];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,17 +8,19 @@
 #include <csignal>
 #include <atomic>
 #include <memory>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 static std::atomic<bool> g_running{true};
 
 static void signal_handler(int signum) {
+#ifndef _WIN32
     const char msg[] = "Shutdown signal received\n";
     ssize_t ret = write(STDERR_FILENO, msg, sizeof(msg) - 1);
     (void)ret;
+#endif
     g_running.store(false, std::memory_order_release);
-    // Restore default handler and re-raise so the process terminates
-    // even if no event loop checks g_running.
     signal(signum, SIG_DFL);
     raise(signum);
 }
@@ -64,12 +66,17 @@ int main(int /*argc*/, char* /*argv*/[]) {
         cfg.overlap_duration_ms, cfg.inference_threads);
 
     // Install signal handlers
+#ifdef _WIN32
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+#else
     struct sigaction sa{};
     sa.sa_handler = signal_handler;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     sigaction(SIGTERM, &sa, nullptr);
     sigaction(SIGINT, &sa, nullptr);
+#endif
 
     // Initialize whisper.cpp backend (required)
     if (cfg.model_path.empty()) {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -98,8 +98,16 @@ TEST(ServerConfig, DefaultLogFormat_IsText) {
 
 // T12-12
 TEST(ServerConfig, LogFormat_FromEnv) {
+#ifdef _WIN32
+    _putenv_s("WSS_LOG_FORMAT", "json");
+#else
     setenv("WSS_LOG_FORMAT", "json", 1);
+#endif
     auto cfg = ServerConfig::from_env();
     EXPECT_EQ(cfg.log_format, "json");
+#ifdef _WIN32
+    _putenv_s("WSS_LOG_FORMAT", "");
+#else
     unsetenv("WSS_LOG_FORMAT");
+#endif
 }


### PR DESCRIPTION
Add platform-portable wrappers for gmtime_r, signal handling, and setenv/unsetenv to enable Windows builds.

Closes #60