### PR TITLE
fix(k8s): add PSS labels, seccomp profile, and GPU network policy

### DIFF
--- a/k8s/deployment-gpu.yaml
+++ b/k8s/deployment-gpu.yaml
@@ -15,8 +15,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: whisperx-server-gpu
+        app.kubernetes.io/part-of: whisperx-streaming-server
     spec:
       terminationGracePeriodSeconds: 120
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: whisperx-server
           image: ghcr.io/vbomfim/openasr:large-v3-cuda

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,8 +15,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: whisperx-server
+        app.kubernetes.io/part-of: whisperx-streaming-server
     spec:
       terminationGracePeriodSeconds: 120
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: whisperx-server
           image: whisperx-server:v0.2.1

--- a/k8s/local/all-in-one.yaml
+++ b/k8s/local/all-in-one.yaml
@@ -61,10 +61,20 @@ spec:
               echo "Verifying SHA-256 checksum..."
               echo "$CHECKSUM  $MODEL" | sha256sum -c - || { echo "CHECKSUM FAILED — removing corrupt model"; rm -f "$MODEL"; exit 1; }
               echo "Model verified: $(ls -lh $MODEL)"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: model-vol
               mountPath: /models
       terminationGracePeriodSeconds: 120
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: whisperx-server
           image: whisperx-server:v0.2.1
@@ -108,6 +118,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: whisperx
     app.kubernetes.io/part-of: whisperx-streaming-server
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: whisperx-server
+      app.kubernetes.io/part-of: whisperx-streaming-server
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
## Summary

Addresses **P0 (Critical)** findings from Platform Guardian audit (#94).

### Changes

| Finding | Description | File(s) |
|---------|-------------|---------|
| #3 | Add Pod Security Standards `restricted` enforcement labels to namespace | `k8s/namespace.yaml` |
| #4 | Fix GPU pods unprotected by NetworkPolicy — use shared `part-of` label selector | `k8s/networkpolicy.yaml`, both deployments |
| #5 | Add `seccompProfile: RuntimeDefault` to all deployments + harden init container | All deployment files |

### Standards
- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) 5.2.1, 5.3.2, 5.7.2
- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) — Restricted profile
- [OWASP Kubernetes Security](https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html)

### Testing
- YAML syntax validated
- No application code changes — infrastructure manifests only

Closes #95