### PR TITLE
fix(k8s): remove committed secret, disable SA token, add default-deny policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ models/
 *.env
 .env*
 secrets/
+k8s/local/secrets.yaml
 
 # Third-party build artifacts
 third_party/whisper.cpp/build/

--- a/k8s/deployment-gpu.yaml
+++ b/k8s/deployment-gpu.yaml
@@ -21,6 +21,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whisperx-server
           image: ghcr.io/vbomfim/openasr:large-v3-cuda

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whisperx-server
           image: whisperx-server:v0.2.1

--- a/k8s/local/all-in-one.yaml
+++ b/k8s/local/all-in-one.yaml
@@ -19,17 +19,11 @@ data:
   WSS_BEAM_SIZE: "5"
   WSS_CONFIG_PATH: "/dev/null"
 ---
+# Secret: whisperx-server-secrets
+# Create manually: kubectl apply -f k8s/local/secrets.yaml
+# See k8s/local/secrets.yaml.example for template
+---
 apiVersion: apps/v1
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: whisperx-server-secrets
-  namespace: whisperx
-type: Opaque
-stringData:
-  WSS_API_KEY: "CHANGE-ME-IN-PRODUCTION"
----
 kind: Deployment
 metadata:
   name: whisperx-server
@@ -75,6 +69,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: whisperx-server
           image: whisperx-server:v0.2.1
@@ -83,9 +78,10 @@ spec:
             - containerPort: 9090
           envFrom:
             - configMapRef:
+                name: whisperx-server-config
             - secretRef:
                 name: whisperx-server-secrets
-                name: whisperx-server-config
+                optional: true
           env:
             - name: WHISPER_MODEL_PATH
               value: /models/ggml-small.en.bin

--- a/k8s/local/secrets.yaml.example
+++ b/k8s/local/secrets.yaml.example
@@ -1,0 +1,15 @@
+# Whisperx Server Secrets Template
+# Copy this file to secrets.yaml and fill in your values:
+#   cp secrets.yaml.example secrets.yaml
+#   $EDITOR secrets.yaml
+#   kubectl apply -f secrets.yaml
+#
+# DO NOT commit secrets.yaml to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: whisperx-server-secrets
+  namespace: whisperx
+type: Opaque
+stringData:
+  WSS_API_KEY: "<your-api-key-here>"

--- a/k8s/networkpolicy-default-deny.yaml
+++ b/k8s/networkpolicy-default-deny.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: whisperx
+  labels:
+    app.kubernetes.io/part-of: whisperx-streaming-server
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
## Summary

Addresses **P1 (High Priority)** findings from Platform Guardian audit (#94).

### Changes

| Finding | Description | File(s) |
|---------|-------------|---------|
| #1 | Remove placeholder secret from VCS; add `secrets.yaml.example` template + `.gitignore` entry | `k8s/local/all-in-one.yaml`, new `secrets.yaml.example`, `.gitignore` |
| #8 | Disable automatic SA token mounting on all deployments | Both deployments + local |
| #11 | Add namespace-wide default-deny NetworkPolicy | New `k8s/networkpolicy-default-deny.yaml` |

### Standards
- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) 5.1.6, 5.3.2, 5.4.1
- [OWASP Kubernetes Security](https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html) — Secret Management, Network Segmentation

### Migration Note
After merging, local dev users must create secrets manually:
```bash
cp k8s/local/secrets.yaml.example k8s/local/secrets.yaml
# Edit secrets.yaml with your values
kubectl apply -f k8s/local/secrets.yaml
```

### Testing
- YAML syntax validated
- No application code changes — infrastructure manifests only

Closes #96