### PR TITLE
fix(k8s): add quotas, PDB, topology spread, CI scanning, restrict DNS egress

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,11 +55,26 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' || inputs.push }}
           tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ env.IMAGE_NAME }}:slim
             ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: spdx-json
+          artifact-name: sbom-slim.spdx.json
 
   build-slim-cuda:
     name: Build slim CUDA image (no model)
@@ -98,11 +113,26 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' || inputs.push }}
           tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:latest-cuda
             ghcr.io/${{ env.IMAGE_NAME }}:slim-cuda
             ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-cuda
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-cuda
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-cuda
+          format: spdx-json
+          artifact-name: sbom-slim-cuda.spdx.json
 
   build-with-model:
     name: Build ${{ matrix.model }} image

--- a/k8s/deployment-gpu.yaml
+++ b/k8s/deployment-gpu.yaml
@@ -25,6 +25,19 @@ spec:
         runAsGroup: 65532
         fsGroup: 65532
       automountServiceAccountToken: false
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: whisperx-server-gpu
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: whisperx-server-gpu
       containers:
         - name: whisperx-server
           image: ghcr.io/vbomfim/openasr:v0.2.1-cuda

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -25,6 +25,19 @@ spec:
         runAsGroup: 65532
         fsGroup: 65532
       automountServiceAccountToken: false
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: whisperx-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: whisperx-server
       containers:
         - name: whisperx-server
           image: ghcr.io/vbomfim/openasr:v0.2.1

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -33,7 +33,9 @@ spec:
   egress:
     # Allow DNS resolution only
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
       ports:
         - protocol: UDP
           port: 53

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: whisperx-server-pdb
+  namespace: whisperx
+  labels:
+    app.kubernetes.io/name: whisperx-server
+    app.kubernetes.io/part-of: whisperx-streaming-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: whisperx-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: whisperx-server-gpu-pdb
+  namespace: whisperx
+  labels:
+    app.kubernetes.io/name: whisperx-server-gpu
+    app.kubernetes.io/part-of: whisperx-streaming-server
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: whisperx-server-gpu

--- a/k8s/resource-quota.yaml
+++ b/k8s/resource-quota.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: whisperx-quota
+  namespace: whisperx
+  labels:
+    app.kubernetes.io/part-of: whisperx-streaming-server
+spec:
+  hard:
+    requests.cpu: "16"
+    requests.memory: "64Gi"
+    limits.cpu: "32"
+    limits.memory: "128Gi"
+    pods: "20"
+    persistentvolumeclaims: "10"
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: whisperx-limits
+  namespace: whisperx
+  labels:
+    app.kubernetes.io/part-of: whisperx-streaming-server
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+        memory: "4Gi"
+      defaultRequest:
+        cpu: "500m"
+        memory: "1Gi"
+      max:
+        cpu: "8"
+        memory: "32Gi"


### PR DESCRIPTION
## Summary

Addresses **P3 (Backlog)** findings from Platform Guardian audit (#94).

### Changes

| Finding | Description | File(s) |
|---------|-------------|---------|
| #13 | Add `ResourceQuota` (16 CPU / 64Gi) and `LimitRange` (default 2 CPU / 4Gi) | New `k8s/resource-quota.yaml` |
| #14 | Add production PodDisruptionBudgets for CPU and GPU deployments | New `k8s/pdb.yaml` |
| #15 | Add `topologySpreadConstraints` (zone + hostname, soft) to both deployments | Both deployments |
| #16 | Remove `:latest` / `:latest-cuda` tags from CI publish workflow | `.github/workflows/docker-publish.yml` |
| #17 | Add Trivy image vulnerability scanning (fail on CRITICAL/HIGH) to CI | `.github/workflows/docker-publish.yml` |
| #18 | Add SBOM generation (SPDX format) to CI | `.github/workflows/docker-publish.yml` |
| #19 | Restrict DNS egress to `kube-system` namespace only | `k8s/networkpolicy.yaml` |

### Standards
- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) 5.2, 5.3.2
- [SLSA Framework](https://slsa.dev/) Level 1-2 — Artifact Immutability, Provenance
- [NIST SP 800-190](https://csrc.nist.gov/publications/detail/sp/800-190/final) §4.1

### Testing
- YAML syntax validated
- GitHub Actions workflow indentation verified
- No application code changes

Closes #98